### PR TITLE
SONARAZDO-386 Bump sonar-scanner-cli to v6

### DIFF
--- a/src/common/latest/config.ts
+++ b/src/common/latest/config.ts
@@ -1,6 +1,6 @@
 // When the user does not specify a specific version, these willl be the default versions used.
 const msBuildVersion = "6.2.0.85879";
-const cliVersion = "5.0.1.3006";
+const cliVersion = "6.0.0.4432";
 
 // MSBUILD scanner location
 const scannersLocation = `https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/`;

--- a/src/extensions/sonarcloud/tasks/SonarCloudAnalyze/v2/task.json
+++ b/src/extensions/sonarcloud/tasks/SonarCloudAnalyze/v2/task.json
@@ -9,7 +9,7 @@
   "author": "sonarsource",
   "version": {
     "Major": 2,
-    "Minor": 0,
+    "Minor": 1,
     "Patch": 0
   },
   "minimumAgentVersion": "3.218.0",

--- a/src/extensions/sonarcloud/tasks/SonarCloudPrepare/v2/task.json
+++ b/src/extensions/sonarcloud/tasks/SonarCloudPrepare/v2/task.json
@@ -9,7 +9,7 @@
   "author": "sonarsource",
   "version": {
     "Major": 2,
-    "Minor": 0,
+    "Minor": 1,
     "Patch": 0
   },
   "minimumAgentVersion": "3.218.0",

--- a/src/extensions/sonarcloud/tasks/SonarCloudPublish/v2/task.json
+++ b/src/extensions/sonarcloud/tasks/SonarCloudPublish/v2/task.json
@@ -9,7 +9,7 @@
   "author": "sonarsource",
   "version": {
     "Major": 2,
-    "Minor": 0,
+    "Minor": 1,
     "Patch": 0
   },
   "minimumAgentVersion": "3.218.0",

--- a/src/extensions/sonarcloud/vss-extension.json
+++ b/src/extensions/sonarcloud/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "sonarcloud",
   "name": "SonarCloud",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "branding": {
     "color": "rgb(243, 243, 243)",
     "theme": "light"

--- a/src/extensions/sonarqube/tasks/SonarQubeAnalyze/v6/task.json
+++ b/src/extensions/sonarqube/tasks/SonarQubeAnalyze/v6/task.json
@@ -9,7 +9,7 @@
   "author": "sonarsource",
   "version": {
     "Major": 6,
-    "Minor": 0,
+    "Minor": 1,
     "Patch": 0
   },
   "releaseNotes": "To be used with the new version of the `Prepare Analysis Configuration` task.",

--- a/src/extensions/sonarqube/tasks/SonarQubePrepare/v6/task.json
+++ b/src/extensions/sonarqube/tasks/SonarQubePrepare/v6/task.json
@@ -9,7 +9,7 @@
   "author": "sonarsource",
   "version": {
     "Major": 6,
-    "Minor": 0,
+    "Minor": 1,
     "Patch": 0
   },
   "releaseNotes": "* __Support non MSBuild projects:__ This task can be used to configure analysis also for non MSBuild projects.",

--- a/src/extensions/sonarqube/tasks/SonarQubePublish/v6/task.json
+++ b/src/extensions/sonarqube/tasks/SonarQubePublish/v6/task.json
@@ -9,7 +9,7 @@
   "author": "sonarsource",
   "version": {
     "Major": 6,
-    "Minor": 0,
+    "Minor": 1,
     "Patch": 0
   },
   "minimumAgentVersion": "3.218.0",

--- a/src/extensions/sonarqube/vss-extension.json
+++ b/src/extensions/sonarqube/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "sonarqube",
   "name": "SonarQube",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "branding": {
     "color": "rgb(67, 157, 210)",
     "theme": "dark"


### PR DESCRIPTION
[ticket](https://sonarsource.atlassian.net/browse/SONARAZDO-386)
- Bump the default scanner version to v6 for SQV2 and SCV6 tasks. 
- This will help mitigate the `ThrowableProxy` error due to `jGit` for SonarCloud users.
- This is a risky release (in rare cases, `sonar-scanner-cli v5 -> v6` is a breaking change (eg when the architecture can't be detected), but we released the new task versions soon, so failing now is acceptable IMO, PMs are OK with the risk as well.

Change validated on SQV6, SCV2, SQV5, SCV1