### PR TITLE
SONARAZDO-378 Rename projects on Next from vsts to azdo

### DIFF
--- a/config/utils.js
+++ b/config/utils.js
@@ -124,12 +124,12 @@ exports.getBuildInfo = function (packageJson, sqExtensionManifest, scExtensionMa
     vcsUrl: `https://github.com/${process.env.CIRRUS_REPO_FULL_NAME}.git`,
     modules: [
       {
-        id: `org.sonarsource.scanner.vsts:${packageJson.name}-sonarqube:${sqPackageVersion}`,
+        id: `org.sonarsource.scanner.azdo:${packageJson.name}-sonarqube:${sqPackageVersion}`,
         properties: {
           artifactsToDownload: sqVsixPaths
             .map(
               (filePath) =>
-                `org.sonarsource.scanner.vsts:${packageJson.name}-sonarqube:vsix:${
+                `org.sonarsource.scanner.azdo:${packageJson.name}-sonarqube:vsix:${
                   filePath.match(sqQualifierMatch)[1]
                 }`,
             )
@@ -146,12 +146,12 @@ exports.getBuildInfo = function (packageJson, sqExtensionManifest, scExtensionMa
         }),
       },
       {
-        id: `org.sonarsource.scanner.vsts:${packageJson.name}-sonarcloud:${scPackageVersion}`,
+        id: `org.sonarsource.scanner.azdo:${packageJson.name}-sonarcloud:${scPackageVersion}`,
         properties: {
           artifactsToDownload: scVsixPaths
             .map(
               (filePath) =>
-                `org.sonarsource.scanner.vsts:${packageJson.name}-sonarcloud:vsix:${
+                `org.sonarsource.scanner.azdo:${packageJson.name}-sonarcloud:vsix:${
                   filePath.match(scQualifierMatch)[1]
                 }`,
             )

--- a/config/utils.js
+++ b/config/utils.js
@@ -193,12 +193,12 @@ exports.runSonarQubeScanner = function (extension, customOptions, callback) {
 
   const baseOptions = {
     sonarqube: {
-      "sonar.projectKey": "org.sonarsource.scanner.vsts:sonar-scanner-vsts",
+      "sonar.projectKey": "sonar-scanner-azdo-sq",
       "sonar.projectName": "Azure DevOps extension for SonarQube",
       "sonar.exclusions": baseExclusions.concat(["src/extensions/sonarcloud/**"]).join(","),
     },
     sonarcloud: {
-      "sonar.projectKey": "org.sonarsource.scanner.vsts:sonar-scanner-vsts-sonarcloud",
+      "sonar.projectKey": "sonar-scanner-azdo-sc",
       "sonar.projectName": "Azure DevOps extension for SonarCloud",
       "sonar.exclusions": baseExclusions.concat(["src/extensions/sonarqube/**"]).join(","),
     },


### PR DESCRIPTION
[ticket](https://sonarsource.atlassian.net/browse/SONARAZDO-378)

Updates the project key on the Next projects ([SC](https://next.sonarqube.com/sonarqube/dashboard?id=org.sonarsource.scanner.vsts%3Asonar-scanner-vsts-sonarcloud), [SQ](https://next.sonarqube.com/sonarqube/dashboard?id=org.sonarsource.scanner.vsts%3Asonar-scanner-vsts))