### PR TITLE
SONARAZDO-385 Allow offline execution for SQV6, SCV2 tasks

### DIFF
--- a/config/paths.js
+++ b/config/paths.js
@@ -43,5 +43,6 @@ exports.BUILD_SCANNER_MSBUILD_DIR = path.join(
 // /dist
 exports.DIST_DIR = path.join(appDirectory, "dist");
 
-exports.BUILD_SCANNER_CLI_DIRNAME = "classic-sonar-scanner-msbuild";
-exports.BUILD_SCANNER_MSBUILD_DIRNAME = "dotnet-sonar-scanner-msbuild";
+exports.BUILD_SCANNER_NET_FRAMEWORK_DIRNAME = "classic-sonar-scanner-msbuild";
+exports.BUILD_SCANNER_NET_DOTNET_DIRNAME = "dotnet-sonar-scanner-msbuild";
+exports.BUILD_SCANNER_CLI_DIRNAME = "sonar-scanner-cli";

--- a/config/utils.js
+++ b/config/utils.js
@@ -217,7 +217,7 @@ exports.runSonarQubeScanner = function (extension, customOptions, callback) {
     "sonar.sources": "src",
     "sonar.projectVersion": vssExtension.version,
     "sonar.coverage.exclusions":
-      "gulpfile.js, build/**, config/**, coverage/**, extensions/**, scripts/**, **/__tests__/**, **/temp-find-method.ts",
+      "gulpfile.js, build/**, config/**, coverage/**, extensions/**, scripts/**, **/__tests__/**, **/mocks/**, **/temp-find-method.ts",
     "sonar.tests": ".",
     "sonar.test.inclusions": "**/__tests__/**",
     "sonar.analysis.buildNumber": process.env.CIRRUS_BUILD_ID,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,7 +21,8 @@ const {
   BUILD_EXTENSION_DIR,
   BUILD_DIR,
   BUILD_SCANNER_DIR,
-  BUILD_SCANNER_MSBUILD_DIRNAME,
+  BUILD_SCANNER_NET_DOTNET_DIRNAME,
+  BUILD_SCANNER_NET_FRAMEWORK_DIRNAME,
   BUILD_SCANNER_CLI_DIRNAME,
   DIST_DIR,
 } = require("./config/paths");
@@ -139,7 +140,9 @@ gulp.task("build:download-scanners", () => {
       downloadOrCopy(scanner.classicUrl)
         .pipe(decompress())
         .pipe(
-          gulp.dest(path.join(BUILD_SCANNER_DIR, BUILD_SCANNER_CLI_DIRNAME, scanner.cliVersion)),
+          gulp.dest(
+            path.join(BUILD_SCANNER_DIR, BUILD_SCANNER_NET_FRAMEWORK_DIRNAME, scanner.cliVersion),
+          ),
         ),
     );
 
@@ -148,10 +151,20 @@ gulp.task("build:download-scanners", () => {
         .pipe(decompress())
         .pipe(
           gulp.dest(
-            path.join(BUILD_SCANNER_DIR, BUILD_SCANNER_MSBUILD_DIRNAME, scanner.msBuildVersion),
+            path.join(BUILD_SCANNER_DIR, BUILD_SCANNER_NET_DOTNET_DIRNAME, scanner.msBuildVersion),
           ),
         ),
     );
+
+    if (scanner.cliUrl) {
+      streams.push(
+        downloadOrCopy(scanner.cliUrl)
+          .pipe(decompress())
+          .pipe(
+            gulp.dest(path.join(BUILD_SCANNER_DIR, BUILD_SCANNER_CLI_DIRNAME, scanner.cliVersion)),
+          ),
+      );
+    }
   }
 
   return mergeStream(streams);
@@ -244,20 +257,27 @@ gulp.task("build:copy", () => {
     if (taskNeedsMsBuildScanner(taskName)) {
       streams.push(
         gulp
-          .src(path.join(BUILD_SCANNER_DIR, BUILD_SCANNER_CLI_DIRNAME, scanner.cliVersion, "**/*"))
-          .pipe(gulp.dest(path.join(outPath, BUILD_SCANNER_CLI_DIRNAME))),
+          .src(
+            path.join(
+              BUILD_SCANNER_DIR,
+              BUILD_SCANNER_NET_FRAMEWORK_DIRNAME,
+              scanner.cliVersion,
+              "**/*",
+            ),
+          )
+          .pipe(gulp.dest(path.join(outPath, BUILD_SCANNER_NET_FRAMEWORK_DIRNAME))),
       );
       streams.push(
         gulp
           .src(
             path.join(
               BUILD_SCANNER_DIR,
-              BUILD_SCANNER_MSBUILD_DIRNAME,
+              BUILD_SCANNER_NET_DOTNET_DIRNAME,
               scanner.msBuildVersion,
               "**/*",
             ),
           )
-          .pipe(gulp.dest(path.join(outPath, BUILD_SCANNER_MSBUILD_DIRNAME))),
+          .pipe(gulp.dest(path.join(outPath, BUILD_SCANNER_NET_DOTNET_DIRNAME))),
       );
     }
   }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -135,25 +135,23 @@ gulp.task("build:download-scanners", () => {
   for (const configJs of configJss) {
     // eslint-disable-next-line import/no-dynamic-require
     const { scanner } = require(configJs);
-    if (scanner.embedScanners) {
-      streams.push(
-        downloadOrCopy(scanner.classicUrl)
-          .pipe(decompress())
-          .pipe(
-            gulp.dest(path.join(BUILD_SCANNER_DIR, BUILD_SCANNER_CLI_DIRNAME, scanner.cliVersion)),
-          ),
-      );
+    streams.push(
+      downloadOrCopy(scanner.classicUrl)
+        .pipe(decompress())
+        .pipe(
+          gulp.dest(path.join(BUILD_SCANNER_DIR, BUILD_SCANNER_CLI_DIRNAME, scanner.cliVersion)),
+        ),
+    );
 
-      streams.push(
-        downloadOrCopy(scanner.dotnetUrl)
-          .pipe(decompress())
-          .pipe(
-            gulp.dest(
-              path.join(BUILD_SCANNER_DIR, BUILD_SCANNER_MSBUILD_DIRNAME, scanner.msBuildVersion),
-            ),
+    streams.push(
+      downloadOrCopy(scanner.dotnetUrl)
+        .pipe(decompress())
+        .pipe(
+          gulp.dest(
+            path.join(BUILD_SCANNER_DIR, BUILD_SCANNER_MSBUILD_DIRNAME, scanner.msBuildVersion),
           ),
-      );
-    }
+        ),
+    );
   }
 
   return mergeStream(streams);
@@ -226,7 +224,7 @@ gulp.task("build:copy", () => {
     const { scanner } = require(configJs);
 
     // Copy Scanner CLI
-    if (taskNeedsCliScanner(taskName) && scanner.embedScanners) {
+    if (taskNeedsCliScanner(taskName)) {
       streams.push(
         gulp
           .src(
@@ -243,7 +241,7 @@ gulp.task("build:copy", () => {
     }
 
     // Copy Scanner MSBuild
-    if (taskNeedsMsBuildScanner(taskName) && scanner.embedScanners) {
+    if (taskNeedsMsBuildScanner(taskName)) {
       streams.push(
         gulp
           .src(path.join(BUILD_SCANNER_DIR, BUILD_SCANNER_CLI_DIRNAME, scanner.cliVersion, "**/*"))
@@ -681,4 +679,3 @@ gulp.task("promote", (done) => {
       done(new Error(err));
     });
 });
-

--- a/src/common/latest/config.ts
+++ b/src/common/latest/config.ts
@@ -1,6 +1,6 @@
 // When the user does not specify a specific version, these willl be the default versions used.
 const msBuildVersion = "6.2.0.85879";
-const cliVersion = "6.0.0.4432";
+const cliVersion = "5.0.1.3006"; // TODO: Change to v6
 
 // MSBUILD scanner location
 const scannersLocation = `https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/`;
@@ -19,16 +19,24 @@ function getCliScannerFilename(cliVersion: string) {
   return `sonar-scanner-cli-${cliVersion}.zip`;
 }
 
+function msBuildUrlTemplate(msBuildVersion: string, framework: boolean) {
+  const filename = framework
+    ? getMsBuildClassicFilename(msBuildVersion)
+    : getMsBuildDotnetFilename(msBuildVersion);
+  return `${scannersLocation}${msBuildVersion}/${filename}`;
+}
+
+function cliUrlTemplate(cliVersion: string) {
+  return `${cliUrl}${getCliScannerFilename(cliVersion)}`;
+}
+
 export const scanner = {
   msBuildVersion,
   cliVersion,
+  classicUrl: msBuildUrlTemplate(msBuildVersion, true),
+  dotnetUrl: msBuildUrlTemplate(msBuildVersion, false),
+  cliUrl: cliUrlTemplate(cliVersion),
 
-  msBuildUrlTemplate: (msBuildVersion: string, isWindows: boolean) => {
-    const filename = isWindows
-      ? getMsBuildClassicFilename(msBuildVersion)
-      : getMsBuildDotnetFilename(msBuildVersion);
-    return `${scannersLocation}${msBuildVersion}/${filename}`;
-  },
-
-  cliUrlTemplate: (cliVersion: string) => `${cliUrl}${getCliScannerFilename(cliVersion)}`,
+  msBuildUrlTemplate,
+  cliUrlTemplate,
 };

--- a/src/common/latest/config.ts
+++ b/src/common/latest/config.ts
@@ -1,6 +1,6 @@
 // When the user does not specify a specific version, these willl be the default versions used.
 const msBuildVersion = "6.2.0.85879";
-const cliVersion = "5.0.1.3006"; // TODO: Change to v6
+const cliVersion = "6.1.0.4477";
 
 // MSBUILD scanner location
 const scannersLocation = `https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/`;

--- a/src/common/latest/helpers/constants.ts
+++ b/src/common/latest/helpers/constants.ts
@@ -13,7 +13,7 @@ export const PROP_NAMES = {
   PROJECTSETTINGS: "project.settings",
 };
 
-export const SCANNER_CLI_FOLDER = "sonar-scanner";
+export const SCANNER_CLI_NAME = "sonar-scanner";
 
 export enum JdkVersionSource {
   JavaHome = "JAVA_HOME",
@@ -45,7 +45,6 @@ export enum TaskVariables {
   SonarEndpoint = "SONAR_ENDPOINT",
   SonarScannerMSBuildExe = "SONAR_SCANNER_MSBUILD_EXE",
   SonarScannerMSBuildDll = "SONAR_SCANNER_MSBUILD_DLL",
-  SonarMsBuildVersion = "SONAR_MSBUILD_VERSION",
   SonarCliVersion = "SONAR_CLI_VERSION",
   SonarScannerLocation = "SONAR_SCANNER_LOCATION",
   JavaHome = "JAVA_HOME",

--- a/src/common/latest/mocks/AzureTaskLibMock.ts
+++ b/src/common/latest/mocks/AzureTaskLibMock.ts
@@ -1,0 +1,93 @@
+import * as tl from "azure-pipelines-task-lib/task";
+import { ToolRunner } from "azure-pipelines-task-lib/toolrunner";
+
+jest.mock("azure-pipelines-task-lib/task");
+jest.mock("azure-pipelines-task-lib/toolrunner");
+
+const DEFAULT_INPUTS = {
+  cliProjectKey: "projectKey",
+};
+
+export class AzureTaskLibMock {
+  platform: tl.Platform = tl.Platform.Linux;
+  inputs: { [key: string]: string } = {};
+  variables: { [key: string]: string } = {};
+  lastToolRunner?: ToolRunner;
+
+  constructor() {
+    jest.mocked(tl.getInput).mockImplementation(this.handleGetInput.bind(this));
+    jest.mocked(tl.getVariable).mockImplementation(this.handleGetVariable.bind(this));
+    jest.mocked(tl.getDelimitedInput).mockImplementation(this.handleGetDelimitedInput.bind(this));
+    jest.mocked(tl.setVariable).mockImplementation(this.handleSetVariable.bind(this));
+    jest.mocked(tl.getPlatform).mockImplementation(() => this.platform);
+    jest.mocked(tl.tool).mockImplementation(this.handleTool.bind(this));
+    jest.mocked(tl.resolve).mockImplementation((...paths) => paths.join("/"));
+    jest.mocked(tl.findMatch).mockImplementation(this.handleFindMatch);
+    jest.mocked(tl.which).mockImplementation((path) => `/bin/${path}`);
+
+    this.reset();
+  }
+
+  setInputs(inputs: { [key: string]: string }) {
+    this.inputs = {
+      ...this.inputs,
+      ...inputs,
+    };
+  }
+
+  setVariables(variables: { [key: string]: string }) {
+    this.variables = {
+      ...this.variables,
+      ...variables,
+    };
+  }
+
+  setPlatform(platform: tl.Platform) {
+    this.platform = platform;
+  }
+
+  getLastToolRunner() {
+    return this.lastToolRunner;
+  }
+
+  handleGetInput(name: string, required = false): string {
+    if (required && !this.inputs[name]) {
+      throw new Error(`Input ${name} is required.`);
+    }
+    return this.inputs[name];
+  }
+
+  handleGetDelimitedInput(name: string, delim: string, required = false) {
+    const input = this.handleGetInput(name, required);
+    return input ? input.split(delim) : [];
+  }
+
+  handleGetVariable(name: string): string | undefined {
+    return this.variables[name];
+  }
+
+  handleSetVariable(name: string, value: string): void {
+    this.variables[name] = value;
+  }
+
+  handleTool(): ToolRunner {
+    this.lastToolRunner = {
+      ...jest.requireActual("azure-pipelines-task-lib/toolrunner").ToolRunner,
+      arg: jest.fn().mockReturnThis(),
+      line: jest.fn().mockReturnThis(),
+      execAsync: jest.fn().mockResolvedValue(0),
+      on: jest.fn().mockImplementation(() => {}),
+    };
+    return this.lastToolRunner;
+  }
+
+  handleFindMatch() {
+    return ["/path/to/mocked/find/match/result"];
+  }
+
+  reset() {
+    this.inputs = { ...DEFAULT_INPUTS };
+    this.variables = {};
+    this.lastToolRunner = undefined;
+  }
+}

--- a/src/common/latest/mocks/AzureToolLibMock.ts
+++ b/src/common/latest/mocks/AzureToolLibMock.ts
@@ -1,0 +1,23 @@
+import * as toolLib from "azure-pipelines-tool-lib/tool";
+
+jest.mock("azure-pipelines-tool-lib/tool");
+
+export class AzureToolLibMock {
+  constructor() {
+    jest.mocked(toolLib.downloadTool).mockImplementation(this.handleDownloadTool.bind(this));
+    jest.mocked(toolLib.extractZip).mockImplementation(this.handleExtractZip.bind(this));
+  }
+
+  handleDownloadTool(): Promise<string> {
+    return Promise.resolve("/some-path/to/tool");
+  }
+
+  handleExtractZip(): Promise<string> {
+    return Promise.resolve("/some-path/to/extracted");
+  }
+
+  reset() {
+    jest.mocked(toolLib.downloadTool).mockClear();
+    jest.mocked(toolLib.extractZip).mockClear();
+  }
+}

--- a/src/common/latest/sonarqube/Scanner.ts
+++ b/src/common/latest/sonarqube/Scanner.ts
@@ -195,7 +195,7 @@ export class ScannerCLI extends Scanner {
 
     // Hotfix permissions on UNIX
     if (!isWindows()) {
-      await fs.chmod(scannerPath, "777");
+      await fs.chmod(scannerPath, "500");
     }
     const scannerRunner = tl.tool(scannerPath);
     this.logIssueOnBuildSummaryForStdErr(scannerRunner);
@@ -303,7 +303,7 @@ export class ScannerMSBuild extends Scanner {
       path.join(path.dirname(scannerExecutablePath), "sonar-scanner-*", "bin", SCANNER_CLI_NAME),
     )[0];
 
-    await fs.chmod(scannerCliShellScripts, "777");
+    await fs.chmod(scannerCliShellScripts, "500");
   }
 
   private getScannerRunner(scannerPath: string, isExeScanner: boolean) {

--- a/src/common/sonarcloud-v1/config.ts
+++ b/src/common/sonarcloud-v1/config.ts
@@ -10,4 +10,5 @@ exports.scanner = {
   cliVersion,
   classicUrl: scannersLocation + classicScannerFilename,
   dotnetUrl: scannersLocation + dotnetScannerFilename,
+  cliUrl: `https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${cliVersion}.zip`,
 };

--- a/src/common/sonarcloud-v1/config.ts
+++ b/src/common/sonarcloud-v1/config.ts
@@ -6,7 +6,6 @@ const classicScannerFilename = `sonar-scanner-msbuild-${msBuildVersion}-net46.zi
 const dotnetScannerFilename = `sonar-scanner-msbuild-${msBuildVersion}-netcoreapp3.0.zip`;
 
 exports.scanner = {
-  embedScanners: true,
   msBuildVersion,
   cliVersion,
   classicUrl: scannersLocation + classicScannerFilename,

--- a/src/common/sonarqube-v4/config.ts
+++ b/src/common/sonarqube-v4/config.ts
@@ -10,4 +10,5 @@ exports.scanner = {
   cliVersion,
   classicUrl: scannersLocation + classicScannerFilename,
   dotnetUrl: scannersLocation + dotnetScannerFilename,
+  cliUrl: `https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${cliVersion}.zip`,
 };

--- a/src/common/sonarqube-v4/config.ts
+++ b/src/common/sonarqube-v4/config.ts
@@ -6,7 +6,6 @@ const classicScannerFilename = `sonar-scanner-msbuild-${msBuildVersion}-net46.zi
 const dotnetScannerFilename = `sonar-scanner-msbuild-${msBuildVersion}-netcoreapp3.0.zip`;
 
 exports.scanner = {
-  embedScanners: true,
   msBuildVersion,
   cliVersion,
   classicUrl: scannersLocation + classicScannerFilename,

--- a/src/common/sonarqube-v5/config.ts
+++ b/src/common/sonarqube-v5/config.ts
@@ -10,4 +10,5 @@ exports.scanner = {
   cliVersion,
   classicUrl: scannersLocation + classicScannerFilename,
   dotnetUrl: scannersLocation + dotnetScannerFilename,
+  cliUrl: `https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${cliVersion}.zip`,
 };

--- a/src/common/sonarqube-v5/config.ts
+++ b/src/common/sonarqube-v5/config.ts
@@ -6,7 +6,6 @@ const classicScannerFilename = `sonar-scanner-msbuild-${msBuildVersion}-net46.zi
 const dotnetScannerFilename = `sonar-scanner-msbuild-${msBuildVersion}-netcoreapp3.0.zip`;
 
 exports.scanner = {
-  embedScanners: true,
   msBuildVersion,
   cliVersion,
   classicUrl: scannersLocation + classicScannerFilename,


### PR DESCRIPTION
- Embed default scanners in SQV6 and SCV2 tasks
  - This PR alsoimplements [SONARAZDO-351](https://sonarsource.atlassian.net/browse/SONARAZDO-351) to build a mocking architecture allowing to mock AzDO variables/input directly rather than assuming the invocation order
- Change build process to support independent msbuild vs scanner cli versions
- Drop `777` permission (replaced with `500`) on scanner files (this is failing SQ scan)

[SONARAZDO-351]: https://sonarsource.atlassian.net/browse/SONARAZDO-351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ