### PR TITLE
SONARAZDO-393 Bump embedded .NET scanner to 7.1

### DIFF
--- a/src/common/latest/config.ts
+++ b/src/common/latest/config.ts
@@ -1,5 +1,5 @@
 // When the user does not specify a specific version, these willl be the default versions used.
-const msBuildVersion = "6.2.0.85879";
+const msBuildVersion = "7.1.1.96069";
 const cliVersion = "6.1.0.4477";
 
 // MSBUILD scanner location

--- a/src/extensions/sonarcloud/tasks/SonarCloudAnalyze/v2/task.json
+++ b/src/extensions/sonarcloud/tasks/SonarCloudAnalyze/v2/task.json
@@ -9,7 +9,7 @@
   "author": "sonarsource",
   "version": {
     "Major": 2,
-    "Minor": 2,
+    "Minor": 3,
     "Patch": 0
   },
   "minimumAgentVersion": "3.218.0",

--- a/src/extensions/sonarcloud/tasks/SonarCloudPrepare/v2/task.json
+++ b/src/extensions/sonarcloud/tasks/SonarCloudPrepare/v2/task.json
@@ -9,7 +9,7 @@
   "author": "sonarsource",
   "version": {
     "Major": 2,
-    "Minor": 2,
+    "Minor": 3,
     "Patch": 0
   },
   "minimumAgentVersion": "3.218.0",

--- a/src/extensions/sonarcloud/tasks/SonarCloudPublish/v2/task.json
+++ b/src/extensions/sonarcloud/tasks/SonarCloudPublish/v2/task.json
@@ -9,7 +9,7 @@
   "author": "sonarsource",
   "version": {
     "Major": 2,
-    "Minor": 2,
+    "Minor": 3,
     "Patch": 0
   },
   "minimumAgentVersion": "3.218.0",

--- a/src/extensions/sonarcloud/vss-extension.json
+++ b/src/extensions/sonarcloud/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "sonarcloud",
   "name": "SonarCloud",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "branding": {
     "color": "rgb(243, 243, 243)",
     "theme": "light"

--- a/src/extensions/sonarqube/tasks/SonarQubeAnalyze/v6/task.json
+++ b/src/extensions/sonarqube/tasks/SonarQubeAnalyze/v6/task.json
@@ -9,7 +9,7 @@
   "author": "sonarsource",
   "version": {
     "Major": 6,
-    "Minor": 2,
+    "Minor": 3,
     "Patch": 0
   },
   "releaseNotes": "To be used with the new version of the `Prepare Analysis Configuration` task.",

--- a/src/extensions/sonarqube/tasks/SonarQubePrepare/v6/task.json
+++ b/src/extensions/sonarqube/tasks/SonarQubePrepare/v6/task.json
@@ -9,7 +9,7 @@
   "author": "sonarsource",
   "version": {
     "Major": 6,
-    "Minor": 2,
+    "Minor": 3,
     "Patch": 0
   },
   "releaseNotes": "* __Support non MSBuild projects:__ This task can be used to configure analysis also for non MSBuild projects.",

--- a/src/extensions/sonarqube/tasks/SonarQubePublish/v6/task.json
+++ b/src/extensions/sonarqube/tasks/SonarQubePublish/v6/task.json
@@ -9,7 +9,7 @@
   "author": "sonarsource",
   "version": {
     "Major": 6,
-    "Minor": 2,
+    "Minor": 3,
     "Patch": 0
   },
   "minimumAgentVersion": "3.218.0",

--- a/src/extensions/sonarqube/vss-extension.json
+++ b/src/extensions/sonarqube/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "sonarqube",
   "name": "SonarQube",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "branding": {
     "color": "rgb(67, 157, 210)",
     "theme": "dark"


### PR DESCRIPTION
[ticket](https://sonarsource.atlassian.net/browse/SONARAZDO-393)

This release is a new major release, but the mentioned breaking change shouldn’t be one for us (change of default sonar.host.url) because we are always specifying it. 
