### PR TITLE
BUILD-5506: Support multiple repox artifacts for sonar-scanner-azdo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v5
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@5.9.2
     with:
       publishToBinaries: true
       slackChannel: team-sc-azdo-extension-release-notif


### PR DESCRIPTION
A fix was made to gh-action_release in https://github.com/SonarSource/gh-action_release/pull/233 to support multiple artifacts in repox (which was implemented as part of https://sonarsource.atlassian.net/browse/SONARAZDO-391)

This PR updates the release workflow to use the new version with the fix. Could you please merge this and do a release to test this? if it goes well, I will update the v5 Branch with the fix and then you can revert this PR.


Please review our [contribution guidelines](https://github.com/SonarSource/sonar-scanner-azdo/blob/master/docs/contributing.md).

And please ensure your pull request adheres to the following guidelines: 

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Provide a unit test for any code you changed
- [x] If there is a [JIRA](https://jira.sonarsource.com/browse/SONARAZDO) ticket available, please make your commits and pull request start with the ticket ID (SONARAZDO-XXXX)
