### PR TITLE
SONARAZDO-395 Revert default .NET scanner version to v6 for SC V2 & SQ V6 tasks

### DIFF
--- a/src/common/latest/config.ts
+++ b/src/common/latest/config.ts
@@ -1,5 +1,5 @@
 // When the user does not specify a specific version, these willl be the default versions used.
-const msBuildVersion = "7.1.1.96069";
+const msBuildVersion = "6.2.0.85879";
 const cliVersion = "6.1.0.4477";
 
 // MSBUILD scanner location

--- a/src/extensions/sonarcloud/tasks/SonarCloudAnalyze/v2/task.json
+++ b/src/extensions/sonarcloud/tasks/SonarCloudAnalyze/v2/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 2,
     "Minor": 3,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "3.218.0",
   "demands": ["java"],

--- a/src/extensions/sonarcloud/tasks/SonarCloudPrepare/v2/task.json
+++ b/src/extensions/sonarcloud/tasks/SonarCloudPrepare/v2/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 2,
     "Minor": 3,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "3.218.0",
   "instanceNameFormat": "Prepare analysis on SonarCloud",

--- a/src/extensions/sonarcloud/tasks/SonarCloudPublish/v2/task.json
+++ b/src/extensions/sonarcloud/tasks/SonarCloudPublish/v2/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 2,
     "Minor": 3,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "3.218.0",
   "inputs": [

--- a/src/extensions/sonarcloud/vss-extension.json
+++ b/src/extensions/sonarcloud/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "sonarcloud",
   "name": "SonarCloud",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "branding": {
     "color": "rgb(243, 243, 243)",
     "theme": "light"

--- a/src/extensions/sonarqube/tasks/SonarQubeAnalyze/v6/task.json
+++ b/src/extensions/sonarqube/tasks/SonarQubeAnalyze/v6/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 6,
     "Minor": 3,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "To be used with the new version of the `Prepare Analysis Configuration` task.",
   "minimumAgentVersion": "3.218.0",

--- a/src/extensions/sonarqube/tasks/SonarQubePrepare/v6/task.json
+++ b/src/extensions/sonarqube/tasks/SonarQubePrepare/v6/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 6,
     "Minor": 3,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "* __Support non MSBuild projects:__ This task can be used to configure analysis also for non MSBuild projects.",
   "minimumAgentVersion": "3.218.0",

--- a/src/extensions/sonarqube/tasks/SonarQubePublish/v6/task.json
+++ b/src/extensions/sonarqube/tasks/SonarQubePublish/v6/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 6,
     "Minor": 3,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "3.218.0",
   "inputs": [

--- a/src/extensions/sonarqube/vss-extension.json
+++ b/src/extensions/sonarqube/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "sonarqube",
   "name": "SonarQube",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "branding": {
     "color": "rgb(67, 157, 210)",
     "theme": "dark"


### PR DESCRIPTION
There has to be 2 releases:
- Users will be automatically moved to this minor patch release
- The next release will be major and will need manual action on users to use the new extension and task versions
- The next release should also come with updated documentation for SQ/SC