### PR TITLE
SONARAZDO-394 Upgrade node-fetch to v3

### DIFF
--- a/src/common/latest/helpers/__tests__/request-test.ts
+++ b/src/common/latest/helpers/__tests__/request-test.ts
@@ -1,0 +1,82 @@
+import * as tl from "azure-pipelines-task-lib/task";
+import fetch from "node-fetch";
+import Endpoint, { EndpointType } from "../../sonarqube/Endpoint";
+import { get } from "../request";
+
+jest.mock("node-fetch", () =>
+  jest.fn().mockResolvedValue({
+    json: jest.fn().mockResolvedValue({ dummy: "data" }),
+    text: jest.fn().mockResolvedValue("foobar"),
+  }),
+);
+
+const MOCKED_ENDPOINT = new Endpoint(EndpointType.SonarQube, { url: "https://endpoint.url" });
+
+describe("request", () => {
+  const originalRequestTimeout = Endpoint.REQUEST_TIMEOUT;
+  beforeEach(() => {
+    Object.defineProperty(Endpoint, "REQUEST_TIMEOUT", { get: () => 1000 });
+  });
+  afterEach(() => {
+    Object.defineProperty(Endpoint, "REQUEST_TIMEOUT", { get: () => originalRequestTimeout });
+    jest.clearAllMocks();
+  });
+
+  it("get without error (text)", async () => {
+    const response = await get(MOCKED_ENDPOINT, "/api/server/version", false, { a: "b" });
+    expect(response).toEqual("foobar");
+
+    const args = (fetch as any).mock.calls[0];
+    expect(args[0]).toBe("https://endpoint.url/api/server/version?a=b");
+    expect(args[1]).toMatchObject({
+      headers: {
+        Authorization: "Basic dW5kZWZpbmVkOg==",
+      },
+      method: "get",
+    });
+  });
+
+  it("get without error (json)", async () => {
+    const response = await get(MOCKED_ENDPOINT, "/api/some-api", true, { a: "b" });
+    expect(response).toEqual({ dummy: "data" });
+
+    const args = (fetch as any).mock.calls[0];
+    expect(args[0]).toBe("https://endpoint.url/api/some-api?a=b");
+    expect(args[1]).toMatchObject({
+      headers: {
+        Authorization: "Basic dW5kZWZpbmVkOg==",
+      },
+      method: "get",
+    });
+  });
+
+  it("get with error", async () => {
+    jest.spyOn(tl, "debug");
+    (fetch as any).mockRejectedValueOnce(new Error("some error"));
+
+    await expect(() => get(MOCKED_ENDPOINT, "/api/some-api", true, { a: "b" })).rejects.toThrow(
+      "some error",
+    );
+
+    expect(tl.debug).toHaveBeenCalledWith(
+      `[SQ] API GET '/api/some-api' failed, error is some error`,
+    );
+  });
+
+  it("get with timeout", async () => {
+    jest.spyOn(tl, "debug");
+    jest.mocked(fetch).mockImplementation((_url, { signal }) => {
+      return new Promise((_resolve, reject) => {
+        signal.addEventListener("abort", () => reject(new Error("Request timeout")));
+      });
+    });
+
+    await expect(() => get(MOCKED_ENDPOINT, "/api/some-api", true, { a: "b" })).rejects.toThrow(
+      "Request timeout",
+    );
+
+    expect(tl.debug).toHaveBeenCalledWith(
+      `[SQ] API GET '/api/some-api' failed, error is Request timeout`,
+    );
+  });
+});

--- a/src/common/latest/package-lock.json
+++ b/src/common/latest/package-lock.json
@@ -15,7 +15,7 @@
         "fs-extra": "11.1.1",
         "guid-typescript": "1.0.9",
         "hpagent": "1.2.0",
-        "node-fetch": "2.7.0",
+        "node-fetch": "3.3.2",
         "semver": "5.7.1"
       },
       "devDependencies": {
@@ -183,6 +183,14 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/deasync": {
       "version": "0.1.29",
       "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.29.tgz",
@@ -221,6 +229,18 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -251,6 +271,17 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/fs-extra": {
@@ -455,23 +486,25 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
       "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg=="
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "version": "3.3.2",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
       },
       "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/nodejs-file-downloader": {
@@ -636,11 +669,6 @@
         "node": ">=8.17.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "node_modules/truncate-utf8-bytes": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
@@ -714,18 +742,12 @@
         "uuid": "bin/uuid"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/wrappy": {
@@ -880,6 +902,11 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
+    "data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
+    },
     "deasync": {
       "version": "0.1.29",
       "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.29.tgz",
@@ -903,6 +930,15 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true
     },
+    "fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "requires": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      }
+    },
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -922,6 +958,14 @@
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
+      }
+    },
+    "formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "requires": {
+        "fetch-blob": "^3.1.2"
       }
     },
     "fs-extra": {
@@ -1081,12 +1125,19 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
       "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg=="
     },
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
+    },
     "node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "version": "3.3.2",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "requires": {
-        "whatwg-url": "^5.0.0"
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
       }
     },
     "nodejs-file-downloader": {
@@ -1207,11 +1258,6 @@
         "rimraf": "^3.0.0"
       }
     },
-    "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "truncate-utf8-bytes": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
@@ -1271,19 +1317,10 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
-    "webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
+    "web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="
     },
     "wrappy": {
       "version": "1.0.2",

--- a/src/common/latest/package.json
+++ b/src/common/latest/package.json
@@ -15,7 +15,7 @@
     "fs-extra": "11.1.1",
     "guid-typescript": "1.0.9",
     "hpagent": "1.2.0",
-    "node-fetch": "2.7.0",
+    "node-fetch": "3.3.2",
     "semver": "5.7.1"
   },
   "overrides": {

--- a/src/common/latest/sonarqube/Endpoint.ts
+++ b/src/common/latest/sonarqube/Endpoint.ts
@@ -6,8 +6,6 @@ import { URL } from "url";
 import { PROP_NAMES } from "../helpers/constants";
 import { getProxyFromURI } from "../helpers/proxyFromEnv";
 
-const REQUEST_TIMEOUT = 60000;
-
 export enum EndpointType {
   SonarCloud = "SonarCloud",
   SonarQube = "SonarQube",
@@ -22,6 +20,8 @@ export interface EndpointData {
 }
 
 export default class Endpoint {
+  static readonly REQUEST_TIMEOUT: number = 60e3;
+
   public type: EndpointType;
 
   private readonly data: EndpointData;
@@ -48,10 +48,10 @@ export default class Endpoint {
     return { username: this.data.token || this.data.username, password: "" };
   }
 
-  toFetchOptions(endpointUrl: string): Partial<RequestInit> {
+  toFetchOptions(endpointUrl: string, signal?: AbortSignal): Partial<RequestInit> {
     const options: Partial<RequestInit> = {
       method: "get",
-      timeout: REQUEST_TIMEOUT,
+      signal,
     };
 
     // Add HTTP auth from this.auth

--- a/src/extensions/sonarcloud/tasks/SonarCloudAnalyze/v2/task.json
+++ b/src/extensions/sonarcloud/tasks/SonarCloudAnalyze/v2/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 2,
     "Minor": 3,
-    "Patch": 1
+    "Patch": 2
   },
   "minimumAgentVersion": "3.218.0",
   "demands": ["java"],

--- a/src/extensions/sonarcloud/tasks/SonarCloudPrepare/v2/task.json
+++ b/src/extensions/sonarcloud/tasks/SonarCloudPrepare/v2/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 2,
     "Minor": 3,
-    "Patch": 1
+    "Patch": 2
   },
   "minimumAgentVersion": "3.218.0",
   "instanceNameFormat": "Prepare analysis on SonarCloud",

--- a/src/extensions/sonarcloud/tasks/SonarCloudPublish/v2/task.json
+++ b/src/extensions/sonarcloud/tasks/SonarCloudPublish/v2/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 2,
     "Minor": 3,
-    "Patch": 1
+    "Patch": 2
   },
   "minimumAgentVersion": "3.218.0",
   "inputs": [

--- a/src/extensions/sonarcloud/vss-extension.json
+++ b/src/extensions/sonarcloud/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "sonarcloud",
   "name": "SonarCloud",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "branding": {
     "color": "rgb(243, 243, 243)",
     "theme": "light"

--- a/src/extensions/sonarqube/tasks/SonarQubeAnalyze/v6/task.json
+++ b/src/extensions/sonarqube/tasks/SonarQubeAnalyze/v6/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 6,
     "Minor": 3,
-    "Patch": 1
+    "Patch": 2
   },
   "releaseNotes": "To be used with the new version of the `Prepare Analysis Configuration` task.",
   "minimumAgentVersion": "3.218.0",

--- a/src/extensions/sonarqube/tasks/SonarQubePrepare/v6/task.json
+++ b/src/extensions/sonarqube/tasks/SonarQubePrepare/v6/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 6,
     "Minor": 3,
-    "Patch": 1
+    "Patch": 2
   },
   "releaseNotes": "* __Support non MSBuild projects:__ This task can be used to configure analysis also for non MSBuild projects.",
   "minimumAgentVersion": "3.218.0",

--- a/src/extensions/sonarqube/tasks/SonarQubePublish/v6/task.json
+++ b/src/extensions/sonarqube/tasks/SonarQubePublish/v6/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 6,
     "Minor": 3,
-    "Patch": 1
+    "Patch": 2
   },
   "minimumAgentVersion": "3.218.0",
   "inputs": [

--- a/src/extensions/sonarqube/vss-extension.json
+++ b/src/extensions/sonarqube/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "sonarqube",
   "name": "SonarQube",
-  "version": "6.3.1",
+  "version": "6.3.2",
   "branding": {
     "color": "rgb(67, 157, 210)",
     "theme": "dark"


### PR DESCRIPTION
This comes from a dogfood thread / support request

We can finally upgrade to `node-fetch@3` on the Node16 tasks

[ticket](https://sonarsource.atlassian.net/browse/SONARAZDO-394)
