### PR TITLE
SONARAZDO-397 Track extension size in pull requests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -60,6 +60,32 @@ build_task:
     - npm run sonarqube
     - npm run upload
 
+check_size_task:
+  <<: *ONLY_SONARSOURCE_QA
+  eks_container:
+    <<: *CONTAINER_TEMPLATE
+    cpu: 3.4
+    memory: 11G
+  env:
+    SONAR_TOKEN: VAULT[development/kv/data/next data.token]
+    SONAR_HOST_URL: VAULT[development/kv/data/next data.url]
+    GPG_SIGNING_KEY: VAULT[development/kv/data/sign data.key]
+    GPG_SIGNING_PASSPHRASE: VAULT[development/kv/data/sign data.passphrase]
+    folder: node_modules
+    SIZE_LIMIT: 30720
+  install_script:
+    - bash scripts/install.sh
+  script:
+    - source cirrus-env BUILD
+    - npm run build
+    - |
+      du -a dist/*.vsix | awk '{print $1}' | xargs -I % bash -c '
+        if [ % -ge $SIZE_LIMIT ]; then
+          echo "Error: File size exceeds limit of $SIZE_LIMIT bytes."
+          exit 1
+        fi
+      '
+
 promote_task:
   depends_on:
     - build


### PR DESCRIPTION
If a pull request bumps one of the `.vsix` file size to >30MB, the `check_size` task will fail with an error:
![image](https://github.com/user-attachments/assets/0d17570f-24dc-44a8-9770-f779fce8ba9b)

BTW I think the limit should be 20MB (because that's the limit for TFS Server 2018), but we currently are over this limit already.