### PR TITLE
SONARAZDO-379 Improve cache strategy for downloaded scanner

### DIFF
--- a/src/common/latest/mocks/AzureToolLibMock.ts
+++ b/src/common/latest/mocks/AzureToolLibMock.ts
@@ -6,6 +6,8 @@ export class AzureToolLibMock {
   constructor() {
     jest.mocked(toolLib.downloadTool).mockImplementation(this.handleDownloadTool.bind(this));
     jest.mocked(toolLib.extractZip).mockImplementation(this.handleExtractZip.bind(this));
+    jest.mocked(toolLib.findLocalTool).mockImplementation(this.handleFindLocalTool.bind(this));
+    jest.mocked(toolLib.cacheDir).mockImplementation(this.handleCacheDir.bind(this));
   }
 
   handleDownloadTool(): Promise<string> {
@@ -16,8 +18,18 @@ export class AzureToolLibMock {
     return Promise.resolve("/some-path/to/extracted");
   }
 
+  handleFindLocalTool(): string {
+    return "";
+  }
+
+  handleCacheDir(): Promise<string> {
+    return Promise.resolve("/some-path/to/cached");
+  }
+
   reset() {
     jest.mocked(toolLib.downloadTool).mockClear();
     jest.mocked(toolLib.extractZip).mockClear();
+    jest.mocked(toolLib.findLocalTool).mockClear();
+    jest.mocked(toolLib.cacheDir).mockClear();
   }
 }


### PR DESCRIPTION
https://sonarsource.atlassian.net/browse/SONARAZDO-379

Findings, azdo hosted agents are ephemeral in nature which means there is no way a task itself can persist files between runs. 

The only way Azure pipelines will persist is by defining a Cache task
https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/cache-v2?view=azure-pipelines

e.g. (probably a simpler key is possible) 

```
- task: Cache@2
  inputs:
    key: 'SonarScanner | "$(Build.SourcesDirectory)/src/extensions/sonarcloud" | "$(Build.SourcesDirectory)/src/extensions/sonarqube"'
    path: '$(Agent.ToolsDirectory)/SonarScanner MSBuild'
    cacheHitVar: 'CACHE_RESTORED'
```

These changes make it possible to check for a cached version, without it; the scanner would ignore a cache even if it was defined, and always download

