### PR TITLE
NO-JIRA Allow local .NET scanner override

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -139,7 +139,7 @@ gulp.task("build:download-scanners", () => {
     // eslint-disable-next-line import/no-dynamic-require
     const { scanner } = require(configJs);
     streams.push(
-      downloadOrCopy(scanner.classicUrl)
+      downloadOrCopy(process.env.SCANNER_NET_FRAMEWORK_LOCATION ?? scanner.classicUrl)
         .pipe(decompress())
         .pipe(
           gulp.dest(
@@ -149,7 +149,7 @@ gulp.task("build:download-scanners", () => {
     );
 
     streams.push(
-      downloadOrCopy(scanner.dotnetUrl)
+      downloadOrCopy(process.env.SCANNER_NET_LOCATION ?? scanner.dotnetUrl)
         .pipe(decompress())
         .pipe(
           gulp.dest(

--- a/src/common/latest/config.ts
+++ b/src/common/latest/config.ts
@@ -3,9 +3,10 @@ const msBuildVersion = "6.2.0.85879";
 const cliVersion = "6.1.0.4477";
 
 // MSBUILD scanner location
-const scannersLocation = `https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/`;
+const dotnetScannersBaseUrl = `https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/`;
+
 // CLI scanner location
-const cliUrl = "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/";
+const cliScannerBaseUrl = "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/";
 
 function getMsBuildClassicFilename(msBuildVersion: string) {
   return `sonar-scanner-${msBuildVersion}-net-framework.zip`;
@@ -23,11 +24,11 @@ function msBuildUrlTemplate(msBuildVersion: string, framework: boolean) {
   const filename = framework
     ? getMsBuildClassicFilename(msBuildVersion)
     : getMsBuildDotnetFilename(msBuildVersion);
-  return `${scannersLocation}${msBuildVersion}/${filename}`;
+  return `${dotnetScannersBaseUrl}${msBuildVersion}/${filename}`;
 }
 
 function cliUrlTemplate(cliVersion: string) {
-  return `${cliUrl}${getCliScannerFilename(cliVersion)}`;
+  return `${cliScannerBaseUrl}${getCliScannerFilename(cliVersion)}`;
 }
 
 export const scanner = {


### PR DESCRIPTION
PR to let .NET squad create builds including custom .NET scanners (not downloaded from GitHub).

How to use:

1. When building the extension, run:

```bash
SCANNER_NET_FRAMEWORK_LOCATION=/path/to/sonar-scanner-9.0.0-rc.99116-net-framework.zip \
SCANNER_NET_LOCATION=/path/to/sonar-scanner-9.0.0-rc.99116-net.zip \
npm run test-build -- --publisher your-publisher

# (Only one of the env var can be set depending on the need).
# - *net-framework.zip is used on windows agents
# - *net.zip is used on linux agents.
```

2. Publish the test extension in under your test publisher, share it with your org then install it
3. Ensure your pipeline does NOT specify `msBuildVersion`, otherwise your embedded scanner won't be used

____

Validated after downloading [v9-rc scanner](https://github.com/SonarSource/sonar-scanner-msbuild/releases/tag/9.0.0-rc.99116) and running the commands above on a Windows agent

![image](https://github.com/user-attachments/assets/2d30e5fd-de07-44c7-91cb-dccef13f552a)
