### PR TITLE
SONARAZDO-396 Include new Scanner .NET v9 in SQ/SC extensions & Bump the embedded Scanner CLI version to v6.2.1

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -72,16 +72,17 @@ check_size_task:
     GPG_SIGNING_KEY: VAULT[development/kv/data/sign data.key]
     GPG_SIGNING_PASSPHRASE: VAULT[development/kv/data/sign data.passphrase]
     folder: node_modules
-    SIZE_LIMIT: 30720
+    MAX_FILE_SIZE_MB: 40
   install_script:
     - bash scripts/install.sh
   script:
     - source cirrus-env BUILD
     - npm run build
     - |
-      du -a dist/*.vsix | awk '{print $1}' | xargs -I % bash -c '
-        if [ % -ge $SIZE_LIMIT ]; then
-          echo "Error: File size exceeds limit of $SIZE_LIMIT bytes."
+      du -a -m dist/*.vsix | awk '{print $1}' | xargs -I % bash -c '
+        echo "File size: % MB"
+        if [ % -ge $MAX_FILE_SIZE_MB ]; then
+          echo "Error: File size exceeds limit of $MAX_FILE_SIZE_MB MB."
           exit 1
         fi
       '

--- a/its/Models/DotnetCoreV3TestCase.cs
+++ b/its/Models/DotnetCoreV3TestCase.cs
@@ -25,7 +25,7 @@ namespace IntegrationTests.Models
 		public DotnetCoreV3TestCase()
 		{
 			Coverage = 0;
-			NcLocs = 807;
+			NcLocs = 1020;
 			PipelineName = "sonarcloud-dotnet-core-v3";
 			ProjectKey = "its-dotnet-core-v3";
 			LogPrefix = "S4NET - .NET Core";

--- a/its/Models/DotnetFrameworkV3TestCase.cs
+++ b/its/Models/DotnetFrameworkV3TestCase.cs
@@ -24,8 +24,8 @@ namespace IntegrationTests.Models
 	{
 		public DotnetFrameworkV3TestCase()
 		{
-			Coverage = 25.0;
-			NcLocs = 49;
+			Coverage = 2.7;
+			NcLocs = 262;
 			PipelineName = "sonarcloud-dotnet-framework-v3";
 			ProjectKey = "its-dotnet-framework-v3";
 			LogPrefix = "S4NET - .NET Framework";

--- a/src/common/latest/config.ts
+++ b/src/common/latest/config.ts
@@ -1,6 +1,6 @@
 // When the user does not specify a specific version, these willl be the default versions used.
 const dotnetScannerVersion = "9.0.0.100868";
-const cliScannerVersion = "6.1.0.4477";
+const cliScannerVersion = "6.2.1.4610";
 
 // MSBUILD scanner location
 const dotnetScannersBaseUrl = `https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/`;

--- a/src/common/latest/config.ts
+++ b/src/common/latest/config.ts
@@ -1,5 +1,5 @@
 // When the user does not specify a specific version, these willl be the default versions used.
-const dotnetScannerVersion = "6.2.0.85879";
+const dotnetScannerVersion = "9.0.0.100868";
 const cliScannerVersion = "6.1.0.4477";
 
 // MSBUILD scanner location

--- a/src/common/sonarcloud-v2/config.ts
+++ b/src/common/sonarcloud-v2/config.ts
@@ -1,6 +1,6 @@
 // When the user does not specify a specific version, these willl be the default versions used.
 const msBuildVersion = "6.2.0.85879";
-const cliVersion = "6.1.0.4477";
+const cliVersion = "6.2.1.4610";
 
 // MSBUILD scanner location
 const scannersLocation = `https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/`;

--- a/src/common/sonarqube-v6/config.ts
+++ b/src/common/sonarqube-v6/config.ts
@@ -1,6 +1,6 @@
 // When the user does not specify a specific version, these willl be the default versions used.
 const msBuildVersion = "6.2.0.85879";
-const cliVersion = "6.1.0.4477";
+const cliVersion = "6.2.1.4610";
 
 // MSBUILD scanner location
 const scannersLocation = `https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/`;


### PR DESCRIPTION
- https://sonarsource.atlassian.net/browse/SONARAZDO-396
- https://sonarsource.atlassian.net/browse/SONARAZDO-410

This bumps the extension size from `24M` to `37M`, because:
- The Scanner CLI size was bumped from `4.7M` to `13M` (due to [this commit](https://github.com/SonarSource/sonar-scanner-cli/commit/8ef04a5f85ae29d14a1bfe4c930ab81e096e5456))
- The Scanner for .NET size was bumped from `2.3M`to `2.6M`
