### PR TITLE
NO-JIRA Fix AzDO quality gate to ignore code coverage on non-latest SQ/SC common folders

### DIFF
--- a/config/utils.js
+++ b/config/utils.js
@@ -188,7 +188,8 @@ exports.runSonarQubeScanner = function (extension, customOptions, callback) {
     "sonar.sources": "src",
     "sonar.projectVersion": vssExtension.version,
     "sonar.coverage.exclusions":
-      "gulpfile.js, build/**, config/**, coverage/**, extensions/**, scripts/**, **/__tests__/**, **/mocks/**, **/temp-find-method.ts",
+      "gulpfile.js, build/**, config/**, coverage/**, extensions/**, scripts/**, **/__tests__/**, **/mocks/**, **/temp-find-method.ts, src/common/sonarqube-v*/**, src/common/sonarcloud-v*/**",
+    "sonar.cpd.exclusions": "src/common/sonarqube-v*/**, src/common/sonarcloud-v*/**",
     "sonar.tests": ".",
     "sonar.test.inclusions": "**/__tests__/**",
     "sonar.analysis.buildNumber": process.env.CIRRUS_BUILD_ID,


### PR DESCRIPTION
For `sonar(qube|cloud)-v*` folders, should:
- Stop checking coverage
- Stop checking duplication 
- Continue finding code smells/hotspots 

It means that when we create a new major task versions, if we have debt on latest, we need to accept the issues on the `sonar(qube|cloud)-v*` folders

I validated this PR with a dummy commit that I will drop after your review