### PR TITLE
SONARAZDO-358 Fix Azure PR decoration in dark themes

### DIFF
--- a/src/common/latest/helpers/html.ts
+++ b/src/common/latest/helpers/html.ts
@@ -32,7 +32,6 @@ export const htmlMainDiv = (content: string) =>
     font-style: normal;
     line-height: normal;
     font-weight: 400;
-    color: rgb(29, 33, 47);
     padding-bottom: 1px;`,
     content,
   );

--- a/src/common/latest/sonarqube/__tests__/__snapshots__/HtmlAnalysisReport-test.ts.snap
+++ b/src/common/latest/sonarqube/__tests__/__snapshots__/HtmlAnalysisReport-test.ts.snap
@@ -6,7 +6,6 @@ exports[`should display the project name 1`] = `
     font-style: normal;
     line-height: normal;
     font-weight: 400;
-    color: rgb(29, 33, 47);
     padding-bottom: 1px;"><div style="font-size: 21px;
     font-weight: 600;"><span>❌</span><span style="
         height: 100%;
@@ -46,7 +45,6 @@ exports[`should generate an analysis status with error 1`] = `
     font-style: normal;
     line-height: normal;
     font-weight: 400;
-    color: rgb(29, 33, 47);
     padding-bottom: 1px;"><div style="font-size: 21px;
     font-weight: 600;"><span>❌</span><span style="
         height: 100%;
@@ -86,7 +84,6 @@ exports[`should not fail when metrics are missing 1`] = `
     font-style: normal;
     line-height: normal;
     font-weight: 400;
-    color: rgb(29, 33, 47);
     padding-bottom: 1px;"><div style="font-size: 21px;
     font-weight: 600;"><span>❌</span><span style="
         height: 100%;
@@ -103,7 +100,6 @@ exports[`should render passing quality gate measures correctly 1`] = `
     font-style: normal;
     line-height: normal;
     font-weight: 400;
-    color: rgb(29, 33, 47);
     padding-bottom: 1px;"><div style="font-size: 21px;
     font-weight: 600;"><span>✅</span><span style="
         height: 100%;
@@ -143,7 +139,6 @@ exports[`should render passing quality gate measures correctly 2`] = `
     font-style: normal;
     line-height: normal;
     font-weight: 400;
-    color: rgb(29, 33, 47);
     padding-bottom: 1px;"><div style="font-size: 21px;
     font-weight: 600;"><span>✅</span><span style="
         height: 100%;


### PR DESCRIPTION
[SONARAZDO-358](https://sonarsource.atlassian.net/browse/SONARAZDO-358)

This simply drops the hardcoded color styling we added on the container div

Screenshots
![image](https://github.com/user-attachments/assets/d20ac2c4-1232-44ff-9b75-7a4f1455cf03)
![image](https://github.com/user-attachments/assets/f409c4b2-68e5-42ec-894f-0d54c5d27760)
![image](https://github.com/user-attachments/assets/2354324a-f00b-4fa1-af2b-d4935626a0e4)
![image](https://github.com/user-attachments/assets/aa774de8-62e7-4f3f-8d94-5d868dbaf160)


[SONARAZDO-358]: https://sonarsource.atlassian.net/browse/SONARAZDO-358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ