### PR TITLE
NO-JIRA Update release notification channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@5.9.2
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@5.10.0
     with:
       publishToBinaries: true
-      slackChannel: team-sc-azdo-extension-release-notif
+      slackChannel: squad-analysis-experience-azdo


### PR DESCRIPTION
To notify the new `azdo` channel rather than the previous unused one