### PR TITLE
SONARAZDO-416 Parallelize IT pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,12 +54,6 @@ stages:
             inputs:
               filePath: "scripts/install.sh"
 
-          - task: Npm@1
-            displayName: "Run Validate-CI"
-            inputs:
-              command: "custom"
-              customCommand: "run validate-ci"
-
           - task: Bash@3
             displayName: "Append build id in version in manifests"
             inputs:

--- a/its/it/cases.ts
+++ b/its/it/cases.ts
@@ -6,7 +6,7 @@ import {
   DUMMY_PROJECT_MAVEN_KEY,
 } from "../constant";
 
-type TestCase = {
+export type TestCase = {
   sonarHostUrl: string;
   projectKey: string;
   pipelineName: string;

--- a/its/it/runner.ts
+++ b/its/it/runner.ts
@@ -1,20 +1,69 @@
+import * as vm from "azure-devops-node-api";
 import { getAzdoApi, runPipeline } from "./azdo";
-import { testCases } from "./cases";
+import { TestCase, testCases } from "./cases";
 import { getLastAnalysisDate } from "./sonar";
+
+/**
+ * We group test cases by project key and parallelize the execution of test cases
+ */
+export function getExecutionPlan(testCases: TestCase[]): TestCase[][] {
+  const groupedTestCases = testCases.reduce(
+    (acc, testCase) => {
+      const { projectKey } = testCase;
+      if (!acc[projectKey]) {
+        acc[projectKey] = [];
+      }
+      acc[projectKey].push(testCase);
+      return acc;
+    },
+    {} as Record<string, TestCase[]>,
+  );
+
+  return Object.values(groupedTestCases);
+}
+
+async function run(
+  azdoApi: vm.WebApi,
+  testCase: TestCase,
+  log: (...args: any[]) => void = console.log,
+) {
+  // Run the pipeline
+  log("Running pipeline");
+  const previousLastAnalysisDate = await getLastAnalysisDate(
+    testCase.sonarHostUrl,
+    testCase.projectKey,
+    log,
+  );
+  await runPipeline(azdoApi, testCase.pipelineName, log);
+
+  // Verify that there was a new analysis after the pipeline run
+  const lastAnalysisDate = await getLastAnalysisDate(
+    testCase.sonarHostUrl,
+    testCase.projectKey,
+    log,
+  );
+  if (!lastAnalysisDate || lastAnalysisDate === previousLastAnalysisDate) {
+    throw new Error("Analysis date did not change");
+  }
+}
 
 export async function main() {
   const azdoApi = getAzdoApi();
 
-  for (const testCase of testCases) {
-    // Run the pipeline
-    console.log(`Running pipeline ${testCase.pipelineName}`);
-    const previousLastAnalysisDate = await getLastAnalysisDate(testCase.sonarHostUrl, testCase.projectKey);
-    await runPipeline(azdoApi, testCase.pipelineName);
+  const executionPlan = getExecutionPlan(testCases);
+  console.log(
+    `Execution plan: \n${executionPlan.map((testCases) => testCases.map((testCase) => testCase.pipelineName)).join("\n")}`,
+  );
 
-    // Verify that there was a new analysis after the pipeline run
-    const lastAnalysisDate = await getLastAnalysisDate(testCase.sonarHostUrl, testCase.projectKey);
-    if (!lastAnalysisDate || lastAnalysisDate === previousLastAnalysisDate) {
-      throw new Error("Analysis date did not change");
-    }
-  }
+  console.log("Running all test cases");
+  await Promise.all(
+    executionPlan.map((testCases) => {
+      return (async () => {
+        for (const testCase of testCases) {
+          const log = (...args: any[]) => console.log(`[${testCase.pipelineName}]`, ...args);
+          await run(azdoApi, testCase, log);
+        }
+      })();
+    }),
+  );
 }

--- a/its/it/sonar.ts
+++ b/its/it/sonar.ts
@@ -4,20 +4,18 @@ import { getBranch, loadEnvironmentVariables } from "./env";
 export async function getLastAnalysisDate(
   sonarHostUrl: string,
   componentKey: string,
+  log: (...args: any[]) => void = console.log,
 ): Promise<string | null> {
   const env = loadEnvironmentVariables();
 
   const url = `${sonarHostUrl}/api/components/show?component=${componentKey}&branch=${getBranch()}&ps=1`;
-  console.log(`Getting last analysis date for ${componentKey} at ${url}...`);
+  log(`Getting last analysis date for ${componentKey} at ${url}...`);
   try {
-    const response = await axios.get(
-      url,
-      {
-        headers: {
-          Authorization: `Bearer ${env.SONARCLOUD_TOKEN}`,
-        },
+    const response = await axios.get(url, {
+      headers: {
+        Authorization: `Bearer ${env.SONARCLOUD_TOKEN}`,
       },
-    );
+    });
     return response.data.component.analysisDate;
   } catch (error: unknown) {
     return null;


### PR DESCRIPTION
Leverages hosted runners concurrency to speed up our pipeline. Tasks are parallelized per project key.
For now, it drops the pipeline total time from `~29min` to `~17.5min`, but this change means that if we add some tests for the CLI Scanner or Maven, Gradle, the pipeline wouldn't take longer, because the longest pipelines are the .net framework ones at the moment (there are 3 of them)

A second commit drops the `validate-ci` check from the Azure pipeline (it's already run in the Cirrus build). This saves almost 3min from the full QA run.

Execution plan as of now:
```text
Execution plan: 
pipeline-sonarcloud-v3-dotnet-8.0.3.99785-windows,pipeline-sonarcloud-v3-dotnet-embedded-windows,pipeline-sonarcloud-v2-dotnet-embedded-windows
pipeline-sonarcloud-v3-dotnet-8.0.3.99785-unix,pipeline-sonarcloud-v3-dotnet-embedded-unix
pipeline-sonarcloud-v3-other-gradle-unix
pipeline-sonarcloud-v3-other-maven-unix
pipeline-sonarcloud-v3-cli-embedded-unix,pipeline-sonarcloud-v3-cli-6.2.1.4610-windows,pipeline-sonarcloud-v1-cli-embedded-unix
``` 

Demo:
![image](https://github.com/user-attachments/assets/a5b4a26e-3089-48aa-8f53-07791d430964)