### PR TITLE
SONARAZDO-439 Fix CI extension version bumps

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -439,7 +439,7 @@ gulp.task("ci:azure:hotfix-extensions-version", () => {
         .pipe(
           gulpJsonEditor((json) => ({
             ...json,
-            version: `${json.version}.${buildNumber}`,
+            version: `10.0.0.${buildNumber}`,
           })),
         )
         .pipe(gulp.dest(path.dirname(vssExtension))),


### PR DESCRIPTION
Always bump the test extension version to `10.0.0.{buildNumber}` to avoid conflicts when we bump minor/patch versions. `10` is an arbitrary choice (it works for me because I already uploaded up to version `8` locally.