### PR TITLE
NO-JIRA Bump latest extension/task versions to 3.1.0 (SQC) and 7.1.0 (SQS)

### DIFF
--- a/src/extensions/sonarcloud/tasks/SonarCloudAnalyze/v3/task.json
+++ b/src/extensions/sonarcloud/tasks/SonarCloudAnalyze/v3/task.json
@@ -9,8 +9,8 @@
   "author": "sonarsource",
   "version": {
     "Major": 3,
-    "Minor": 0,
-    "Patch": 4
+    "Minor": 1,
+    "Patch": 0
   },
   "minimumAgentVersion": "3.218.0",
   "demands": ["java"],

--- a/src/extensions/sonarcloud/tasks/SonarCloudPrepare/v3/task.json
+++ b/src/extensions/sonarcloud/tasks/SonarCloudPrepare/v3/task.json
@@ -9,8 +9,8 @@
   "author": "sonarsource",
   "version": {
     "Major": 3,
-    "Minor": 0,
-    "Patch": 4
+    "Minor": 1,
+    "Patch": 0
   },
   "minimumAgentVersion": "3.218.0",
   "instanceNameFormat": "Prepare analysis on SonarQube Cloud",

--- a/src/extensions/sonarcloud/tasks/SonarCloudPublish/v3/task.json
+++ b/src/extensions/sonarcloud/tasks/SonarCloudPublish/v3/task.json
@@ -9,8 +9,8 @@
   "author": "sonarsource",
   "version": {
     "Major": 3,
-    "Minor": 0,
-    "Patch": 4
+    "Minor": 1,
+    "Patch": 0
   },
   "minimumAgentVersion": "3.218.0",
   "inputs": [

--- a/src/extensions/sonarcloud/vss-extension.json
+++ b/src/extensions/sonarcloud/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "sonarcloud",
   "name": "SonarQube Cloud",
-  "version": "3.0.4",
+  "version": "3.1.0",
   "branding": {
     "color": "rgb(243, 243, 243)",
     "theme": "light"

--- a/src/extensions/sonarqube/tasks/SonarQubeAnalyze/v7/task.json
+++ b/src/extensions/sonarqube/tasks/SonarQubeAnalyze/v7/task.json
@@ -9,8 +9,8 @@
   "author": "sonarsource",
   "version": {
     "Major": 7,
-    "Minor": 0,
-    "Patch": 4
+    "Minor": 1,
+    "Patch": 0
   },
   "releaseNotes": "To be used with the new version of the `Prepare Analysis Configuration` task.",
   "minimumAgentVersion": "3.218.0",

--- a/src/extensions/sonarqube/tasks/SonarQubePrepare/v7/task.json
+++ b/src/extensions/sonarqube/tasks/SonarQubePrepare/v7/task.json
@@ -9,8 +9,8 @@
   "author": "sonarsource",
   "version": {
     "Major": 7,
-    "Minor": 0,
-    "Patch": 4
+    "Minor": 1,
+    "Patch": 0
   },
   "releaseNotes": "* __Support non MSBuild projects:__ This task can be used to configure analysis also for non MSBuild projects.",
   "minimumAgentVersion": "3.218.0",

--- a/src/extensions/sonarqube/tasks/SonarQubePublish/v7/task.json
+++ b/src/extensions/sonarqube/tasks/SonarQubePublish/v7/task.json
@@ -9,8 +9,8 @@
   "author": "sonarsource",
   "version": {
     "Major": 7,
-    "Minor": 0,
-    "Patch": 4
+    "Minor": 1,
+    "Patch": 0
   },
   "minimumAgentVersion": "3.218.0",
   "inputs": [

--- a/src/extensions/sonarqube/vss-extension.json
+++ b/src/extensions/sonarqube/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "sonarqube",
   "name": "SonarQube Server",
-  "version": "7.0.4",
+  "version": "7.1.0",
   "branding": {
     "color": "rgb(67, 157, 210)",
     "theme": "dark"


### PR DESCRIPTION
- Bump latest SonarQube Server extension versions to `7.1.0`
- Bump latest SonarQube Cloud extension versions to `3.1.0`

So that users get the rebranded extension/tasks