### PR TITLE
SONARAZDO-440 Forward the cliSources input as intended to the CLI Scanner

### DIFF
--- a/src/extensions/sonarcloud/tasks/SonarCloudPrepare/v3/task.json
+++ b/src/extensions/sonarcloud/tasks/SonarCloudPrepare/v3/task.json
@@ -145,7 +145,7 @@
     },
     {
       "name": "cliSources",
-      "type": "filePath",
+      "type": "string",
       "label": "Sources directory root",
       "defaultValue": ".",
       "required": true,

--- a/src/extensions/sonarqube/tasks/SonarQubePrepare/v7/task.json
+++ b/src/extensions/sonarqube/tasks/SonarQubePrepare/v7/task.json
@@ -135,7 +135,7 @@
     },
     {
       "name": "cliSources",
-      "type": "filePath",
+      "type": "string",
       "label": "Sources directory root",
       "defaultValue": ".",
       "required": true,


### PR DESCRIPTION
[ticket](https://sonarsource.atlassian.net/browse/SONARAZDO-440)

## Changes

What this PR changes is that the RAW value of `cliSources` is now used instead of the converted value to an absolute path:
![image](https://github.com/user-attachments/assets/dd5eafb7-db7c-42ef-9d5a-4a339b6dca44) (before)
vs
![image](https://github.com/user-attachments/assets/93e80b35-9c79-4aca-8097-1f08b2c974a4) (now)


## Demo

Assuming a repository structure like this:
```text
- docs-src/src/components
```

With this setup:
```yml
- task: SonarCloudPrepare@3
  inputs:
    [..]
    cliSources: src\components
    extraProperties: |
      sonar.projectBaseDir=$(Build.SourcesDirectory)\docs-src
```

The value of `cliSources` is changed before it is setn to the task to be an absolute path starting from the repository root (not `projectBaseDir`). Therefore the analysis fails

![image](https://github.com/user-attachments/assets/2997d382-ee80-433b-a683-fa232d556995)

With this fix, with the same task definition, we can see the results on SonarQube Cloud which is as expected

![image](https://github.com/user-attachments/assets/76a7c9f6-d949-49ff-8214-9b76652da12c)
