### PR TITLE
SONARAZDO-444 Fix marketplace title background color to match rebranded logos

### DIFF
--- a/src/extensions/sonarcloud/vss-extension.json
+++ b/src/extensions/sonarcloud/vss-extension.json
@@ -4,7 +4,7 @@
   "name": "SonarQube Cloud",
   "version": "3.1.1",
   "branding": {
-    "color": "rgb(243, 243, 243)",
+    "color": "rgb(244, 247, 251)",
     "theme": "light"
   },
   "publisher": "sonarsource",

--- a/src/extensions/sonarqube/vss-extension.json
+++ b/src/extensions/sonarqube/vss-extension.json
@@ -4,8 +4,8 @@
   "name": "SonarQube Server",
   "version": "7.1.1",
   "branding": {
-    "color": "rgb(67, 157, 210)",
-    "theme": "dark"
+    "color": "rgb(244, 247, 251)",
+    "theme": "light"
   },
   "publisher": "sonarsource",
   "homepage": "https://www.sonarsource.com",


### PR DESCRIPTION
Marketplace pages:
- https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud
- https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube

Current backgrounds
![image](https://github.com/user-attachments/assets/fba74d77-6cb2-48c2-bfad-b8d210f2b7d2)
![image](https://github.com/user-attachments/assets/fe2d7912-cd9a-4abb-a6cc-784b19543c31)

Problem
- SonarQube Cloud extension should use a background color from the rebranded color palette (N2: `rgb(244, 247, 251)`)
- SonarQube Server extension should use a light background with the new background color `N2` as well