### PR TITLE
SONARAZDO-446 Fix Azure DevOps & Cirrus CI QA

### DIFF
--- a/.cirrus/Dockerfile
+++ b/.cirrus/Dockerfile
@@ -16,12 +16,7 @@ FROM ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j17-latest
 USER root
 
 RUN apt-get update -y && \
-    apt-get install -y libicu-dev ca-certificates curl gnupg
-RUN mkdir -p /etc/apt/keyrings
-RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-ENV NODE_MAJOR=20
-RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
-RUN apt-get update && apt-get install nodejs -y
+    apt-get install -y libicu-dev nodejs
 
 
 ENV CYCLONEDX_CLI_VERSION=v0.24.0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,6 +30,7 @@ variables:
   - name: azureBranch
     value: $[coalesce(variables['System.PullRequest.SourceBranch'], 'master')]
 
+
 stages:
   - stage: build
     displayName: "Build:"
@@ -46,7 +47,7 @@ stages:
             inputs:
               targetType: "inline"
               script: |
-                sudo npm i -g npm@latest
+                sudo npm i -g npm@10
 
           - task: Bash@3
             displayName: "Install all extension dependencies"


### PR DESCRIPTION
Both the Cirrus and Azure DevOps QA are failing, but for different reasons. Justifications are in [SONARAZDO-446](https://sonarsource.atlassian.net/browse/SONARAZDO-446).

Failing pipelines:
- [Azure DevOps](https://dev.azure.com/sonarsource/SonarScannerAzdo/_build/results?buildId=108453&view=logs&j=f1338668-1e5b-508a-0652-45679475677e&t=2f3fd90c-e401-5d08-e0c9-5abd54dad81f&l=64)
- [Cirrus CI](https://cirrus-ci.com/task/5768958130782208?logs=build#L160)

Commits:
- [Fix the Azure DevOps CI by pinning NPM version to 11](https://github.com/SonarSource/sonar-scanner-azdo/pull/457/commits/c3398be6d9fe6ec383fce5c8348cbf250f0eb57c)
- [Rely on APT to install NodeJS 18](https://github.com/SonarSource/sonar-scanner-azdo/pull/457/commits/374008cbaa87e56c081dc10f818848ffa7c120bd)


[SONARAZDO-446]: https://sonarsource.atlassian.net/browse/SONARAZDO-446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ