### PR TITLE
SONARAZDO-458 Bump Scanner for .NET 10.1.0.110937

### DIFF
--- a/src/common/latest/config.ts
+++ b/src/common/latest/config.ts
@@ -1,5 +1,5 @@
 // When the user does not specify a specific version, these willl be the default versions used.
-const dotnetScannerVersion = "10.1.0.110937";
+const dotnetScannerVersion = "10.1.1.111189";
 const cliScannerVersion = "6.2.1.4610";
 
 // MSBUILD scanner location

--- a/src/common/latest/config.ts
+++ b/src/common/latest/config.ts
@@ -1,5 +1,5 @@
 // When the user does not specify a specific version, these willl be the default versions used.
-const dotnetScannerVersion = "9.0.2.104486";
+const dotnetScannerVersion = "10.1.0.110937";
 const cliScannerVersion = "6.2.1.4610";
 
 // MSBUILD scanner location

--- a/src/extensions/sonarcloud/tasks/SonarCloudAnalyze/v3/task.json
+++ b/src/extensions/sonarcloud/tasks/SonarCloudAnalyze/v3/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 3,
     "Minor": 2,
-    "Patch": 1
+    "Patch": 0
   },
   "minimumAgentVersion": "3.218.0",
   "demands": ["java"],

--- a/src/extensions/sonarcloud/tasks/SonarCloudAnalyze/v3/task.json
+++ b/src/extensions/sonarcloud/tasks/SonarCloudAnalyze/v3/task.json
@@ -9,7 +9,7 @@
   "author": "sonarsource",
   "version": {
     "Major": 3,
-    "Minor": 1,
+    "Minor": 2,
     "Patch": 1
   },
   "minimumAgentVersion": "3.218.0",

--- a/src/extensions/sonarcloud/tasks/SonarCloudPrepare/v3/task.json
+++ b/src/extensions/sonarcloud/tasks/SonarCloudPrepare/v3/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 3,
     "Minor": 2,
-    "Patch": 1
+    "Patch": 0
   },
   "minimumAgentVersion": "3.218.0",
   "instanceNameFormat": "Prepare analysis on SonarQube Cloud",

--- a/src/extensions/sonarcloud/tasks/SonarCloudPrepare/v3/task.json
+++ b/src/extensions/sonarcloud/tasks/SonarCloudPrepare/v3/task.json
@@ -9,7 +9,7 @@
   "author": "sonarsource",
   "version": {
     "Major": 3,
-    "Minor": 1,
+    "Minor": 2,
     "Patch": 1
   },
   "minimumAgentVersion": "3.218.0",

--- a/src/extensions/sonarcloud/tasks/SonarCloudPublish/v3/task.json
+++ b/src/extensions/sonarcloud/tasks/SonarCloudPublish/v3/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 3,
     "Minor": 2,
-    "Patch": 1
+    "Patch": 0
   },
   "minimumAgentVersion": "3.218.0",
   "inputs": [

--- a/src/extensions/sonarcloud/tasks/SonarCloudPublish/v3/task.json
+++ b/src/extensions/sonarcloud/tasks/SonarCloudPublish/v3/task.json
@@ -9,7 +9,7 @@
   "author": "sonarsource",
   "version": {
     "Major": 3,
-    "Minor": 1,
+    "Minor": 2,
     "Patch": 1
   },
   "minimumAgentVersion": "3.218.0",

--- a/src/extensions/sonarcloud/vss-extension.json
+++ b/src/extensions/sonarcloud/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "sonarcloud",
   "name": "SonarQube Cloud",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "branding": {
     "color": "rgb(244, 247, 251)",
     "theme": "light"

--- a/src/extensions/sonarqube/tasks/SonarQubeAnalyze/v7/task.json
+++ b/src/extensions/sonarqube/tasks/SonarQubeAnalyze/v7/task.json
@@ -9,8 +9,8 @@
   "author": "sonarsource",
   "version": {
     "Major": 7,
-    "Minor": 1,
-    "Patch": 1
+    "Minor": 2,
+    "Patch": 0
   },
   "releaseNotes": "To be used with the new version of the `Prepare Analysis Configuration` task.",
   "minimumAgentVersion": "3.218.0",

--- a/src/extensions/sonarqube/tasks/SonarQubePrepare/v7/task.json
+++ b/src/extensions/sonarqube/tasks/SonarQubePrepare/v7/task.json
@@ -9,8 +9,8 @@
   "author": "sonarsource",
   "version": {
     "Major": 7,
-    "Minor": 1,
-    "Patch": 1
+    "Minor": 2,
+    "Patch": 0
   },
   "releaseNotes": "* __Support non MSBuild projects:__ This task can be used to configure analysis also for non MSBuild projects.",
   "minimumAgentVersion": "3.218.0",

--- a/src/extensions/sonarqube/tasks/SonarQubePublish/v7/task.json
+++ b/src/extensions/sonarqube/tasks/SonarQubePublish/v7/task.json
@@ -9,8 +9,8 @@
   "author": "sonarsource",
   "version": {
     "Major": 7,
-    "Minor": 1,
-    "Patch": 1
+    "Minor": 2,
+    "Patch": 0
   },
   "minimumAgentVersion": "3.218.0",
   "inputs": [

--- a/src/extensions/sonarqube/vss-extension.json
+++ b/src/extensions/sonarqube/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "sonarqube",
   "name": "SonarQube Server",
-  "version": "7.1.1",
+  "version": "7.2.0",
   "branding": {
     "color": "rgb(244, 247, 251)",
     "theme": "light"


### PR DESCRIPTION
[SONARAZDO-458](https://sonarsource.atlassian.net/browse/SONARAZDO-458)

AzDevops extensions also need a version bump as in #426

[SONARAZDO-458]: https://sonarsource.atlassian.net/browse/SONARAZDO-458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ