### PR TITLE
SONARAZDO-465 Use Bearer authentication for Axios when contacting SonarQube Cloud

### DIFF
--- a/src/common/latest/helpers/__tests__/request-test.ts
+++ b/src/common/latest/helpers/__tests__/request-test.ts
@@ -24,7 +24,7 @@ jest.mock("azure-pipelines-task-lib/task");
 
 describe("request", () => {
   describe("get", () => {
-    it("should get a JSON response with auth", async () => {
+    it("should get a JSON response with token auth", async () => {
       axiosMock
         .onGet(`${ENDPOINT.url}/api/server/version`, {
           params: {
@@ -40,9 +40,8 @@ describe("request", () => {
 
       const args = axiosMock.history.get[0];
       expect(args).toMatchObject({
-        auth: {
-          username: "the-token",
-          password: "",
+        headers: {
+          Authorization: `Bearer the-token`,
         },
         timeout: Endpoint.REQUEST_TIMEOUT,
       });

--- a/src/common/latest/helpers/constants.ts
+++ b/src/common/latest/helpers/constants.ts
@@ -4,7 +4,7 @@ export const PROP_NAMES = {
   HOST_URL: "sonar.host.url",
   TOKEN: "sonar.token",
   LOGIN: "sonar.login",
-  PASSSWORD: "sonar.password",
+  PASSWORD: "sonar.password",
   ORG: "sonar.organization",
   PROJECTKEY: "sonar.projectKey",
   PROJECTNAME: "sonar.projectName",

--- a/src/common/latest/helpers/utils.ts
+++ b/src/common/latest/helpers/utils.ts
@@ -16,7 +16,7 @@ export function stringifyScannerParams(scannerParams: ScannerParams) {
 
 export function sanitizeScannerParams(scannerParams: ScannerParams) {
   delete scannerParams[PROP_NAMES.LOGIN];
-  delete scannerParams[PROP_NAMES.PASSSWORD];
+  delete scannerParams[PROP_NAMES.PASSWORD];
   return scannerParams;
 }
 

--- a/src/common/latest/sonarqube/Endpoint.ts
+++ b/src/common/latest/sonarqube/Endpoint.ts
@@ -42,7 +42,6 @@ export default class Endpoint {
   }
 
   public get auth(): { username: string; password: string } {
-    // If using user/password
     if (
       !this.data.token &&
       this.data.username &&
@@ -57,11 +56,19 @@ export default class Endpoint {
   toAxiosOptions(): AxiosRequestConfig {
     const options: AxiosRequestConfig = {
       timeout: Endpoint.REQUEST_TIMEOUT,
-      auth: {
+    };
+
+    const isSonarCloud = Boolean(this.data.token);
+    if (isSonarCloud) {
+      options.headers = {
+        Authorization: `Bearer ${this.data.token}`,
+      };
+    } else {
+      options.auth = {
         username: this.auth.username,
         password: this.auth.password,
-      },
-    };
+      };
+    }
 
     // Fetch proxy from environment
     // We ignore proxy set by agent proxy configuration, we need to discuss whether we want to itroduce it
@@ -101,7 +108,7 @@ export default class Endpoint {
     return {
       [PROP_NAMES.HOST_URL]: this.data.url,
       [authKey]: this.data.token || this.data.username,
-      [PROP_NAMES.PASSSWORD]:
+      [PROP_NAMES.PASSWORD]:
         this.data.password && this.data.password.length > 0 ? this.data.password : null,
       [PROP_NAMES.ORG]: this.data.organization,
     };

--- a/src/common/latest/sonarqube/__tests__/Endpoint-test.ts
+++ b/src/common/latest/sonarqube/__tests__/Endpoint-test.ts
@@ -31,7 +31,7 @@ it("On SonarQube Cloud, password is always null", () => {
 
   const result = Endpoint.getEndpoint("sonarcloud", EndpointType.Cloud);
 
-  expect(result.toSonarProps("7.1.0")[PROP_NAMES.PASSSWORD]).toBeNull();
+  expect(result.toSonarProps("7.1.0")[PROP_NAMES.PASSWORD]).toBeNull();
   expect(result.auth.password).toBe("");
 });
 
@@ -45,7 +45,7 @@ it("On SonarQube Server, password is empty should not be intepreted", () => {
 
   const result = Endpoint.getEndpoint("sonarqube", EndpointType.Server);
 
-  expect(result.toSonarProps("7.1.0")[PROP_NAMES.PASSSWORD]).toBeNull();
+  expect(result.toSonarProps("7.1.0")[PROP_NAMES.PASSWORD]).toBeNull();
   expect(result.auth.password).toBe("");
 });
 
@@ -58,7 +58,7 @@ it("On SonarQube Server password is not empty should be intepreted", () => {
 
   const result = Endpoint.getEndpoint("sonarqube", EndpointType.Server);
 
-  expect(result.toSonarProps("7.1.0")[PROP_NAMES.PASSSWORD]).toEqual("P@ssword");
+  expect(result.toSonarProps("7.1.0")[PROP_NAMES.PASSWORD]).toEqual("P@ssword");
   expect(result.auth.password).toEqual("P@ssword");
 });
 


### PR DESCRIPTION
[SONARAZDO-465](https://sonarsource.atlassian.net/browse/SONARAZDO-465)

We can't do it for SonarQube Server as older versions were only supporting passing the token through BASIC authentication.


[SONARAZDO-465]: https://sonarsource.atlassian.net/browse/SONARAZDO-465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ