### PR TITLE
SONARAZDO-603 Workaround for request timeout issues on extension publish step

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -166,7 +166,25 @@ stages:
               updateTasksId: false
               extensionVisibility: "private"
               shareWith: "$(itOrg)"
+              # Let tfx exit right after the upload. Waiting for Marketplace validation inside the
+              # publish command makes a transient timeout fail a step that cannot safely be retried.
+              noWaitValidation: true
               cwd: "$(System.ArtifactsDirectory)"
+
+          # Wait for validation in a dedicated, read-only step that is safe to retry
+          - task: IsAzureDevOpsExtensionValid@5
+            displayName: "Wait for Marketplace validation of the test extension"
+            retryCountOnTaskFailure: 3
+            inputs:
+              connectTo: "AzureRM"
+              connectedServiceNameAzureRM: "$(MarketplaceARMServiceConnection)"
+              method: "id"
+              publisherId: "$(publisher)"
+              extensionId: "sonarcloud-test"
+              extensionVersion: "$(scExtensionVersion)"
+              maxRetries: "10"
+              minTimeout: "0.5"
+
           # Install extension
           - task: InstallAzureDevOpsExtension@5
             displayName: "Install Test extension in IT org"
@@ -257,7 +275,21 @@ stages:
               updateTasksId: false
               extensionVisibility: "private"
               shareWith: "sonarsource"
+              noWaitValidation: true
               cwd: "$(System.ArtifactsDirectory)"
+
+          - task: IsAzureDevOpsExtensionValid@5
+            displayName: "Wait for Marketplace validation of the SonarCloud dogfood extension"
+            retryCountOnTaskFailure: 3
+            inputs:
+              connectTo: "AzureRM"
+              connectedServiceNameAzureRM: "$(MarketplaceARMServiceConnection)"
+              method: "id"
+              publisherId: "$(publisher)"
+              extensionId: "sonarcloud-dogfood"
+              extensionVersion: "$(scExtensionVersion)"
+              maxRetries: "10"
+              minTimeout: "0.5"
 
           - task: PublishAzureDevOpsExtension@5
             displayName: "Publish SonarQube Server dogfood extension"
@@ -272,4 +304,18 @@ stages:
               updateTasksId: false
               extensionVisibility: "private"
               shareWith: "sonarsource"
+              noWaitValidation: true
               cwd: "$(System.ArtifactsDirectory)"
+
+          - task: IsAzureDevOpsExtensionValid@5
+            displayName: "Wait for Marketplace validation of the SonarQube Server dogfood extension"
+            retryCountOnTaskFailure: 3
+            inputs:
+              connectTo: "AzureRM"
+              connectedServiceNameAzureRM: "$(MarketplaceARMServiceConnection)"
+              method: "id"
+              publisherId: "$(publisher)"
+              extensionId: "sonarqube-dogfood"
+              extensionVersion: "$(sqExtensionVersion)"
+              maxRetries: "10"
+              minTimeout: "0.5"


### PR DESCRIPTION
## Validation

The pipeline ran with only a few seconds to publish the test extension. Most time is spent validating the extension, in our example there was 5 attempts. (cf. screenshots below)

<img width="1197" height="749" alt="azdo1" src="https://github.com/user-attachments/assets/b06e5cb2-b1e8-487b-8655-8fa69789951b" />
<img width="1228" height="1198" alt="azdo2" src="https://github.com/user-attachments/assets/f0980834-67d4-4f46-b449-f7db705ab660" />


----
## Summary by Gitar

- **CI/CD Pipelines:**
    - Added `noWaitValidation: true` to extension publish tasks to avoid transient timeouts
    - Introduced dedicated `IsAzureDevOpsExtensionValid@5` validation steps with retry logic

<sub>This will update automatically on new commits.</sub>